### PR TITLE
set credentialsResponseBody

### DIFF
--- a/src/Provider.php
+++ b/src/Provider.php
@@ -25,6 +25,7 @@ class Provider extends AbstractProvider implements ProviderInterface
 
     /**
      * set Open Id.
+     *
      * @param string $openId
      */
     public function setOpenId($openId)

--- a/src/Provider.php
+++ b/src/Provider.php
@@ -14,9 +14,23 @@ class Provider extends AbstractProvider implements ProviderInterface
     const IDENTIFIER = 'WEIXINWEB';
 
     /**
+     * @var string
+     */
+    protected $openId;
+
+    /**
      * {@inheritdoc}.
      */
     protected $scopes = ['snsapi_login'];
+
+    /**
+     * set Open Id
+     * @param string $openId
+     */
+    public function setOpenId($openId)
+    {
+        $this->openId = $openId;
+    }
 
     /**
      * {@inheritdoc}.
@@ -65,7 +79,7 @@ class Provider extends AbstractProvider implements ProviderInterface
         $response = $this->getHttpClient()->get('https://api.weixin.qq.com/sns/userinfo', [
             'query' => [
                 'access_token' => $token,
-                'openid' => $this->credentialsResponseBody['openid'],
+                'openid' => $this->openId,
                 'lang' => 'zh_CN',
             ],
         ]);
@@ -105,6 +119,7 @@ class Provider extends AbstractProvider implements ProviderInterface
         ]);
 
         $this->credentialsResponseBody = json_decode($response->getBody(), true);
+        $this->openId = $this->credentialsResponseBody['openid'];
 
         return $this->parseAccessToken($response->getBody());
     }

--- a/src/Provider.php
+++ b/src/Provider.php
@@ -16,11 +16,6 @@ class Provider extends AbstractProvider implements ProviderInterface
     /**
      * {@inheritdoc}.
      */
-    protected $openId;
-
-    /**
-     * {@inheritdoc}.
-     */
     protected $scopes = ['snsapi_login'];
 
     /**

--- a/src/Provider.php
+++ b/src/Provider.php
@@ -24,7 +24,7 @@ class Provider extends AbstractProvider implements ProviderInterface
     protected $scopes = ['snsapi_login'];
 
     /**
-     * set Open Id
+     * set Open Id.
      * @param string $openId
      */
     public function setOpenId($openId)

--- a/src/Provider.php
+++ b/src/Provider.php
@@ -108,5 +108,4 @@ class Provider extends AbstractProvider implements ProviderInterface
 
         return $this->parseAccessToken($response->getBody());
     }
-
 }


### PR DESCRIPTION
1. Remove the protected function `removeCallback` which has not been called
2. The current class extends from `SocialiteProviders\Manager\OAuth2\AbstractProvider`, and it override the function `getAccessToken`, so we must set the value of `$this->credentialsResponseBody`, otherwise it will error here:
   https://github.com/SocialiteProviders/Manager/blob/master/src/OAuth2/AbstractProvider.php#L59
3. The protected function  `getUserByToken` of this Provider needs one more property named `openId`.  So we must call `setOpenId` method to set the `openid` before calling `userFromToken`.

All codes have been tested.
