### PR TITLE
Fix wrong composer package name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # WeixinWeb
 
 ```bash
-composer require socialiteproviders/weixinweb
+composer require socialiteproviders/weixin-web
 ```
 
 ## Installation & Basic Usage


### PR DESCRIPTION
For: https://github.com/SocialiteProviders/website/issues/50

Fix:
`socialiteproviders/weixinweb` does not exist, it should be `socialiteproviders/weixin-web`.